### PR TITLE
Add a convenient mechanism for observing media status

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -19,6 +19,7 @@ import {
     IReceiverStatus,
 } from "./util/protocol";
 import { delay, throwCancellationIfAborted } from "./util/async";
+import { receiveMediaStatus } from "./media";
 
 const HEARTBEAT_INTERVAL = 30000;
 const HEARTBEAT_TIMEOUT = 5000;
@@ -106,6 +107,10 @@ export class ChromecastDevice {
         const { status } = await receiver.send(GET_STATUS_PAYLOAD, opts);
         debug("got status=", JSON.stringify(status, null, 2));
         return status as unknown as IReceiverStatus;
+    }
+
+    public receiveMediaStatus(opts: IReceiveOpts = {}) {
+        return receiveMediaStatus(this, opts);
     }
 
     public close() {

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,0 +1,50 @@
+import _debug from "debug";
+
+import type { ChromecastDevice } from "./device";
+import { IReceiveOpts, isJson } from "./socket";
+import CancellationError from "./util/CancellationError";
+import {
+    GET_STATUS_PAYLOAD, IReceiverStatus, MEDIA_NS, RECEIVER_NS,
+} from "./util/protocol";
+
+const debug = _debug("stratocaster:media");
+
+const RECEIVER_STATUS = "RECEIVER_STATUS";
+const MEDIA_STATUS = "MEDIA_STATUS";
+
+export async function* receiveMediaStatus(device: ChromecastDevice, opts: IReceiveOpts = {}) {
+    const receiver = await device.channel(RECEIVER_NS, opts);
+    const status = await receiver.send(GET_STATUS_PAYLOAD) as unknown as IReceiverStatus;
+
+    let media = await device.channel(MEDIA_NS, {
+        ...opts,
+        destination: status.applications?.[0]?.transportId,
+    });
+
+    try {
+        /* eslint-disable no-await-in-loop */
+        while (opts.signal?.aborted !== true) {
+            const message = await Promise.race([media.receiveOne(opts), receiver.receiveOne(opts)]);
+            if (!isJson(message.data)) {
+                continue;
+            }
+
+            if (message.data.type === RECEIVER_STATUS) {
+                debug("Receiver status changed");
+                const data = message.data as unknown as IReceiverStatus;
+                media = await device.channel(MEDIA_NS, {
+                    ...opts,
+                    destination: data.applications?.[0]?.sessionId,
+                });
+                await media.write({ type: "GET_STATUS" });
+            } else if (message.data.type === MEDIA_STATUS) {
+                // TODO add type
+                yield message.data;
+            }
+        }
+    } catch (e) {
+        if (!(e instanceof CancellationError)) {
+            throw e;
+        }
+    }
+}

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,10 +1,17 @@
 import _debug from "debug";
+import { StratoChannel } from "./channel";
 
 import type { ChromecastDevice } from "./device";
 import { IReceiveOpts, isJson } from "./socket";
 import CancellationError from "./util/CancellationError";
 import {
-    GET_STATUS_PAYLOAD, IReceiverStatus, MEDIA_NS, RECEIVER_NS,
+    GET_STATUS_PAYLOAD,
+    IMediaStatus,
+    IMediaStatuses,
+    IReceiverStatus,
+    MEDIA_NS,
+    PlayerState,
+    RECEIVER_NS,
 } from "./util/protocol";
 
 const debug = _debug("stratocaster:media");
@@ -12,34 +19,85 @@ const debug = _debug("stratocaster:media");
 const RECEIVER_STATUS = "RECEIVER_STATUS";
 const MEDIA_STATUS = "MEDIA_STATUS";
 
+const IDLE_MEDIA_STATUS: IMediaStatus = {
+    mediaSessionId: 0,
+    playbackRate: 1,
+    playerState: PlayerState.IDLE,
+    supportedMediaCommands: 0,
+    volume: { level: 1, muted: false },
+};
+
 export async function* receiveMediaStatus(device: ChromecastDevice, opts: IReceiveOpts = {}) {
     const receiver = await device.channel(RECEIVER_NS, opts);
-    const status = await receiver.send(GET_STATUS_PAYLOAD) as unknown as IReceiverStatus;
+    const statusMessage = await receiver.send(GET_STATUS_PAYLOAD);
+    let lastStatus = statusMessage.status as unknown as IReceiverStatus;
+    let media: StratoChannel | undefined;
+    let currentMediaStatus: IMediaStatus = IDLE_MEDIA_STATUS;
 
-    let media = await device.channel(MEDIA_NS, {
-        ...opts,
-        destination: status.applications?.[0]?.transportId,
-    });
+    yield currentMediaStatus;
 
     try {
         /* eslint-disable no-await-in-loop */
         while (opts.signal?.aborted !== true) {
-            const message = await Promise.race([media.receiveOne(opts), receiver.receiveOne(opts)]);
+            // If a new media app has started (or the last one was stopped) switch
+            // to the new one. Note that if the app doesn't support the media NS then
+            // this is sorta pointless, but it *does* simplify the type checks below.
+            if (media == null) {
+                const app = lastStatus.applications?.[0];
+                const destination = app?.transportId;
+                media = await device.channel(MEDIA_NS, {
+                    ...opts,
+                    destination,
+                });
+
+                // If media is indeed supported, request the initial state. This is
+                // important as otherwise we don't get pushed updates!
+                if (app?.namespaces?.find(({ name }) => name === MEDIA_NS)) {
+                    debug("Observe media on transportId", destination);
+
+                    const response = await media.send(GET_STATUS_PAYLOAD);
+                    debug("initial media status=", response);
+
+                    // *How* would we destructure this, eslint?
+                    // eslint-disable-next-line prefer-destructuring
+                    currentMediaStatus = (response.status as IMediaStatuses)[0];
+                    yield currentMediaStatus;
+                }
+            }
+
+            debug("await message...");
+            const message = await Promise.race([
+                media.receiveOne(opts),
+                receiver.receiveOne(opts),
+            ]);
             if (!isJson(message.data)) {
                 continue;
             }
 
             if (message.data.type === RECEIVER_STATUS) {
-                debug("Receiver status changed");
-                const data = message.data as unknown as IReceiverStatus;
-                media = await device.channel(MEDIA_NS, {
-                    ...opts,
-                    destination: data.applications?.[0]?.sessionId,
-                });
-                await media.write({ type: "GET_STATUS" });
+                const nextStatus = message.data.status as unknown as IReceiverStatus;
+                if (debug.enabled) {
+                    debug("Receiver status changed", JSON.stringify(lastStatus, null, 2));
+                }
+
+                const app = nextStatus.applications?.[0];
+                const destination = app?.transportId;
+
+                if (destination !== lastStatus.applications?.[0]?.transportId) {
+                    lastStatus = nextStatus;
+                    media = undefined;
+                    currentMediaStatus = IDLE_MEDIA_STATUS;
+                    yield currentMediaStatus;
+                    debug("Receiver transport changed changed");
+                }
             } else if (message.data.type === MEDIA_STATUS) {
-                // TODO add type
-                yield message.data;
+                // Pushed statuses are partials:
+                if (debug.enabled) {
+                    debug("Received media status", JSON.stringify(message.data, null, 2));
+                }
+                const statuses = message.data.status as IMediaStatuses;
+                currentMediaStatus = { ...currentMediaStatus, ...statuses[0] };
+                yield currentMediaStatus;
             }
         }
     } catch (e) {

--- a/src/util/protocol.ts
+++ b/src/util/protocol.ts
@@ -25,11 +25,62 @@ export interface IReceiverApp {
 
 export interface IReceiverStatus {
     applications: IReceiverApp[];
-    userEq: unknown,
+    userEq: unknown;
     volume: {
-        controlType: "attenuation",
-        level: number,
-        muted: boolean,
-        stepInterval: number,
-    }
+        controlType: "attenuation";
+        level: number;
+        muted: boolean;
+        stepInterval: number;
+    };
 }
+
+export enum PlayerState {
+    BUFFERING = "BUFFERING",
+    IDLE = "IDLE",
+    PAUSED = "PAUSED",
+    PLAYING = "PLAYING",
+}
+
+export interface IMediaInformation {
+    breakClips?: unknown[];
+    breaks?: unknown[];
+    contentId: string;
+    contentType: string;
+    contentUrl?: string;
+    customData: Record<string, unknown>;
+    duration?: number;
+    entity?: string;
+    mediaCategory?: "AUDIO" | "VIDEO" | "IMAGE";
+    metadata?: Record<string, unknown>;
+    startAbsoluteTime?: number;
+    streamType: "BUFFERED" | "LIVE" | "NONE";
+    textTrackStyle?: unknown;
+    tracks?: unknown[];
+    userActionStates?: unknown[];
+    vmapAdsRequest?: unknown;
+}
+
+export interface IMediaStatus {
+    activeTrackIds?: number[];
+    breakStatus?: unknown; // TODO
+    currentItemId?: number;
+    currentTime?: number;
+    customData?: Record<string, unknown>;
+    extendedStatus?: unknown; // TODO
+    idleReason?: unknown; // TODO
+    items?: unknown[]; // TODO
+    liveSeekableRange?: unknown;
+    media?: IMediaInformation;
+    mediaSessionId: number;
+    playbackRate: number;
+    playerState: PlayerState;
+    preloadedItemId?: number;
+    supportedMediaCommands: number;
+    videoInfo?: unknown;
+    volume: {
+        level: number;
+        muted: boolean;
+    };
+}
+
+export type IMediaStatuses = IMediaStatus[];


### PR DESCRIPTION
This seems like a common enough use-case that it seems to make sense to have a high-level primitive for it, since doing so by hand is a bit... tricky. Basically, any time the active app changes (indicated by a `RECEIVER_STATUS` message) we will need to re-subscribe to the new app's media channel in order to get updates from it.
